### PR TITLE
Allow CompositeJson(De)SerializerFactory

### DIFF
--- a/plugin/compiler/src/main/kotlin/com/jaynewstrom/json/compiler/DeserializerFactoryBuilder.kt
+++ b/plugin/compiler/src/main/kotlin/com/jaynewstrom/json/compiler/DeserializerFactoryBuilder.kt
@@ -1,75 +1,28 @@
 package com.jaynewstrom.json.compiler
 
-import com.jaynewstrom.json.compiler.JsonCompiler.Companion.QUESTION_MARK_WILDCARD_TYPE_NAME
-import com.jaynewstrom.json.runtime.JsonDeserializer
 import com.jaynewstrom.json.runtime.JsonDeserializerFactory
 import com.squareup.javapoet.ClassName
-import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.MethodSpec
-import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
-import com.squareup.javapoet.TypeVariableName
-import java.util.LinkedHashMap
 import javax.lang.model.element.Modifier
 
 data class DeserializerFactoryBuilder(val deserializers: Collection<TypeName>) {
-    companion object {
-        private const val DESERIALIZER_MAP_NAME = "deserializerMap"
-        private val JSON_DESERIALIZER_TYPE_NAME = ParameterizedTypeName.get(ClassName.get(JsonDeserializer::class.java),
-                QUESTION_MARK_WILDCARD_TYPE_NAME)
-    }
-
     fun build(): TypeSpec {
         return TypeSpec.classBuilder("RealJsonDeserializerFactory")
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addSuperinterface(ClassName.get(JsonDeserializerFactory::class.java))
-                .addField(createDeserializerMapField())
+                .superclass(ClassName.get(JsonDeserializerFactory::class.java))
                 .addMethod(createConstructor())
-                .addMethod(createRegisterMethod())
-                .addMethod(createGetMethod())
                 .build()
-    }
-
-    private fun createDeserializerMapField(): FieldSpec {
-        val classTypeName = ParameterizedTypeName.get(ClassName.get(Class::class.java), QUESTION_MARK_WILDCARD_TYPE_NAME)
-        val rawMapTypeName = ClassName.get(Map::class.java)
-        val mapTypeName = ParameterizedTypeName.get(rawMapTypeName, classTypeName, JSON_DESERIALIZER_TYPE_NAME)
-        return FieldSpec.builder(mapTypeName, DESERIALIZER_MAP_NAME, Modifier.PRIVATE, Modifier.FINAL).build()
     }
 
     private fun createConstructor(): MethodSpec {
         val constructorBuilder = MethodSpec.constructorBuilder()
         constructorBuilder.addModifiers(Modifier.PUBLIC)
-        val mapSize = JsonCompiler.mapSize(deserializers)
-        constructorBuilder.addStatement("this.$DESERIALIZER_MAP_NAME = new \$T<>(\$L)", LinkedHashMap::class.java, mapSize)
-        JsonCompiler.registerDefaultJsonAdapters(constructorBuilder)
         deserializers.forEach {
             val codeFormat = "register(new \$T())"
             constructorBuilder.addStatement(codeFormat, it)
         }
         return constructorBuilder.build()
-    }
-
-    private fun createRegisterMethod(): MethodSpec {
-        return MethodSpec.methodBuilder("register")
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(JSON_DESERIALIZER_TYPE_NAME, "jsonDeserializer")
-                .addStatement("$DESERIALIZER_MAP_NAME.put(jsonDeserializer.modelClass(), jsonDeserializer)")
-                .build()
-    }
-
-    private fun createGetMethod(): MethodSpec {
-        val typeParameter = TypeVariableName.get("T")
-        val jsonDeserializerTypeName = ParameterizedTypeName.get(ClassName.get(JsonDeserializer::class.java), typeParameter)
-        return MethodSpec.methodBuilder("get")
-                .addAnnotation(Override::class.java)
-                .addModifiers(Modifier.PUBLIC)
-                .addTypeVariable(typeParameter)
-                .returns(jsonDeserializerTypeName)
-                .addParameter(ParameterizedTypeName.get(ClassName.get(Class::class.java), typeParameter), "modelClass")
-                .addComment("noinspection unchecked")
-                .addStatement("return (\$T) $DESERIALIZER_MAP_NAME.get(modelClass)", jsonDeserializerTypeName)
-                .build()
     }
 }

--- a/plugin/compiler/src/main/kotlin/com/jaynewstrom/json/compiler/JsonCompiler.kt
+++ b/plugin/compiler/src/main/kotlin/com/jaynewstrom/json/compiler/JsonCompiler.kt
@@ -1,13 +1,5 @@
 package com.jaynewstrom.json.compiler
 
-import com.jaynewstrom.json.runtime.internal.BooleanJsonAdapter
-import com.jaynewstrom.json.runtime.internal.ByteJsonAdapter
-import com.jaynewstrom.json.runtime.internal.DoubleJsonAdapter
-import com.jaynewstrom.json.runtime.internal.FloatJsonAdapter
-import com.jaynewstrom.json.runtime.internal.IntegerJsonAdapter
-import com.jaynewstrom.json.runtime.internal.LongJsonAdapter
-import com.jaynewstrom.json.runtime.internal.ShortJsonAdapter
-import com.jaynewstrom.json.runtime.internal.StringJsonAdapter
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterizedTypeName
@@ -45,23 +37,6 @@ class JsonCompiler {
                     .returns(ParameterizedTypeName.get(ClassName.get(Class::class.java), WildcardTypeName.subtypeOf(Any::class.java)))
                     .addStatement("return \$T.class", JsonCompiler.jsonModelType(modelName))
                     .build()
-        }
-
-        fun registerDefaultJsonAdapters(methodBuilder: MethodSpec.Builder) {
-            val codeFormat = "register(\$T.INSTANCE)"
-            methodBuilder.addStatement(codeFormat, ClassName.get(BooleanJsonAdapter::class.java))
-            methodBuilder.addStatement(codeFormat, ClassName.get(ByteJsonAdapter::class.java))
-            methodBuilder.addStatement(codeFormat, ClassName.get(DoubleJsonAdapter::class.java))
-            methodBuilder.addStatement(codeFormat, ClassName.get(FloatJsonAdapter::class.java))
-            methodBuilder.addStatement(codeFormat, ClassName.get(IntegerJsonAdapter::class.java))
-            methodBuilder.addStatement(codeFormat, ClassName.get(LongJsonAdapter::class.java))
-            methodBuilder.addStatement(codeFormat, ClassName.get(ShortJsonAdapter::class.java))
-            methodBuilder.addStatement(codeFormat, ClassName.get(StringJsonAdapter::class.java))
-        }
-
-        fun mapSize(list: Collection<Any>): Int {
-            // Try and initialize the map to a size where it won't need to be expanded.
-            return (Math.round((list.size + 10) * 1.4)).toInt()
         }
     }
 }

--- a/plugin/compiler/src/main/kotlin/com/jaynewstrom/json/compiler/SerializerFactoryBuilder.kt
+++ b/plugin/compiler/src/main/kotlin/com/jaynewstrom/json/compiler/SerializerFactoryBuilder.kt
@@ -1,75 +1,28 @@
 package com.jaynewstrom.json.compiler
 
-import com.jaynewstrom.json.compiler.JsonCompiler.Companion.QUESTION_MARK_WILDCARD_TYPE_NAME
-import com.jaynewstrom.json.runtime.JsonSerializer
 import com.jaynewstrom.json.runtime.JsonSerializerFactory
 import com.squareup.javapoet.ClassName
-import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.MethodSpec
-import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
-import com.squareup.javapoet.TypeVariableName
-import java.util.LinkedHashMap
 import javax.lang.model.element.Modifier
 
 data class SerializerFactoryBuilder(val serializers: Collection<TypeName>) {
     fun build(): TypeSpec {
         return TypeSpec.classBuilder("RealJsonSerializerFactory")
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addSuperinterface(ClassName.get(JsonSerializerFactory::class.java))
-                .addField(createSerializerMapField())
+                .superclass(ClassName.get(JsonSerializerFactory::class.java))
                 .addMethod(createConstructor())
-                .addMethod(createRegisterMethod())
-                .addMethod(createGetMethod())
                 .build()
-    }
-
-    private fun createSerializerMapField(): FieldSpec {
-        val classTypeName = ParameterizedTypeName.get(ClassName.get(Class::class.java), QUESTION_MARK_WILDCARD_TYPE_NAME)
-        val rawMapTypeName = ClassName.get(Map::class.java)
-        val mapTypeName = ParameterizedTypeName.get(rawMapTypeName, classTypeName, JSON_SERIALIZER_TYPE_NAME)
-        return FieldSpec.builder(mapTypeName, SERIALIZER_MAP_NAME, Modifier.PRIVATE, Modifier.FINAL).build()
     }
 
     private fun createConstructor(): MethodSpec {
         val constructorBuilder = MethodSpec.constructorBuilder()
         constructorBuilder.addModifiers(Modifier.PUBLIC)
-        val mapSize = JsonCompiler.mapSize(serializers)
-        constructorBuilder.addStatement("this.$SERIALIZER_MAP_NAME = new \$T<>(\$L)", LinkedHashMap::class.java, mapSize)
-        JsonCompiler.registerDefaultJsonAdapters(constructorBuilder)
         serializers.forEach {
             val codeFormat = "register(new \$T())"
             constructorBuilder.addStatement(codeFormat, it)
         }
         return constructorBuilder.build()
-    }
-
-    private fun createRegisterMethod(): MethodSpec {
-        return MethodSpec.methodBuilder("register")
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(JSON_SERIALIZER_TYPE_NAME, "jsonSerializer")
-                .addStatement("$SERIALIZER_MAP_NAME.put(jsonSerializer.modelClass(), jsonSerializer)")
-                .build()
-    }
-
-    private fun createGetMethod(): MethodSpec {
-        val typeParameter = TypeVariableName.get("T")
-        val jsonSerializerTypeName = ParameterizedTypeName.get(ClassName.get(JsonSerializer::class.java), typeParameter)
-        return MethodSpec.methodBuilder("get")
-                .addAnnotation(Override::class.java)
-                .addModifiers(Modifier.PUBLIC)
-                .addTypeVariable(typeParameter)
-                .returns(jsonSerializerTypeName)
-                .addParameter(ParameterizedTypeName.get(ClassName.get(Class::class.java), typeParameter), "modelClass")
-                .addComment("noinspection unchecked")
-                .addStatement("return (\$T) $SERIALIZER_MAP_NAME.get(modelClass)", jsonSerializerTypeName)
-                .build()
-    }
-
-    companion object {
-        private const val SERIALIZER_MAP_NAME = "deserializerMap"
-        private val JSON_SERIALIZER_TYPE_NAME = ParameterizedTypeName.get(ClassName.get(JsonSerializer::class.java),
-                QUESTION_MARK_WILDCARD_TYPE_NAME)
     }
 }

--- a/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/CompositeJsonDeserializerFactory.java
+++ b/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/CompositeJsonDeserializerFactory.java
@@ -1,0 +1,10 @@
+package com.jaynewstrom.json.runtime;
+
+public final class CompositeJsonDeserializerFactory extends JsonDeserializerFactory {
+    public CompositeJsonDeserializerFactory() {
+    }
+
+    public final void registerAll(JsonDeserializerFactory deserializerFactory) {
+        deserializerMap.putAll(deserializerFactory.deserializerMap);
+    }
+}

--- a/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/CompositeJsonSerializerFactory.java
+++ b/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/CompositeJsonSerializerFactory.java
@@ -1,0 +1,10 @@
+package com.jaynewstrom.json.runtime;
+
+public final class CompositeJsonSerializerFactory extends JsonSerializerFactory {
+    public CompositeJsonSerializerFactory() {
+    }
+
+    public final void registerAll(JsonSerializerFactory serializerFactory) {
+        serializerMap.putAll(serializerFactory.serializerMap);
+    }
+}

--- a/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/JsonDeserializerFactory.java
+++ b/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/JsonDeserializerFactory.java
@@ -1,5 +1,38 @@
 package com.jaynewstrom.json.runtime;
 
-public interface JsonDeserializerFactory {
-    <T> JsonDeserializer<T> get(Class<T> modelClass);
+import com.jaynewstrom.json.runtime.internal.BooleanJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.ByteJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.DoubleJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.FloatJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.IntegerJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.LongJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.ShortJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.StringJsonAdapter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class JsonDeserializerFactory {
+    final Map<Class<?>, JsonDeserializer<?>> deserializerMap;
+
+    public JsonDeserializerFactory() {
+        deserializerMap = new LinkedHashMap<>();
+        register(BooleanJsonAdapter.INSTANCE);
+        register(ByteJsonAdapter.INSTANCE);
+        register(DoubleJsonAdapter.INSTANCE);
+        register(FloatJsonAdapter.INSTANCE);
+        register(IntegerJsonAdapter.INSTANCE);
+        register(LongJsonAdapter.INSTANCE);
+        register(ShortJsonAdapter.INSTANCE);
+        register(StringJsonAdapter.INSTANCE);
+    }
+
+    public final <T> JsonDeserializer<T> get(Class<T> modelClass) {
+        // noinspection unchecked
+        return (JsonDeserializer<T>) deserializerMap.get(modelClass);
+    }
+
+    public final void register(JsonDeserializer<?> jsonDeserializer) {
+        deserializerMap.put(jsonDeserializer.modelClass(), jsonDeserializer);
+    }
 }

--- a/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/JsonSerializerFactory.java
+++ b/plugin/runtime/src/main/java/com/jaynewstrom/json/runtime/JsonSerializerFactory.java
@@ -1,5 +1,38 @@
 package com.jaynewstrom.json.runtime;
 
-public interface JsonSerializerFactory {
-    <T> JsonSerializer<T> get(Class<T> modelClass);
+import com.jaynewstrom.json.runtime.internal.BooleanJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.ByteJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.DoubleJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.FloatJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.IntegerJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.LongJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.ShortJsonAdapter;
+import com.jaynewstrom.json.runtime.internal.StringJsonAdapter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class JsonSerializerFactory {
+    final Map<Class<?>, JsonSerializer<?>> serializerMap;
+
+    public JsonSerializerFactory() {
+        serializerMap = new LinkedHashMap<>();
+        register(BooleanJsonAdapter.INSTANCE);
+        register(ByteJsonAdapter.INSTANCE);
+        register(DoubleJsonAdapter.INSTANCE);
+        register(FloatJsonAdapter.INSTANCE);
+        register(IntegerJsonAdapter.INSTANCE);
+        register(LongJsonAdapter.INSTANCE);
+        register(ShortJsonAdapter.INSTANCE);
+        register(StringJsonAdapter.INSTANCE);
+    }
+
+    public final void register(JsonSerializer<?> jsonSerializer) {
+        serializerMap.put(jsonSerializer.modelClass(), jsonSerializer);
+    }
+
+    public final <T> JsonSerializer<T> get(Class<T> modelClass) {
+        // noinspection unchecked
+        return (JsonSerializer<T>) serializerMap.get(modelClass);
+    }
 }


### PR DESCRIPTION
This makes it so you can have a project with multiple modules, all generating their own `RealJson(De)SerializerFactory`, and they can be combined into one big `CompositeJson(De)SerializerFactory` which can be used in the retrofit converter.